### PR TITLE
Handle new "queued" job status

### DIFF
--- a/catalyze/helpers/jobs.py
+++ b/catalyze/helpers/jobs.py
@@ -23,7 +23,7 @@ def poll_brrgc_task(session, env_id, svc_id, task_id):
 def poll_until_complete(session, env_id, svc_id, job_id):
     while True:
         job = retrieve(session, env_id, svc_id, job_id)
-        if job["status"] not in ["scheduled", "started", "running"]:
+        if job["status"] not in ["scheduled", "queued", "started", "running"]:
             if job["status"] == "finished":
                 return job
             else:

--- a/catalyze/helpers/tasks.py
+++ b/catalyze/helpers/tasks.py
@@ -8,7 +8,7 @@ def poll_status(session, env_id, task_id):
     while True:
         time.sleep(2)
         task = session.get(route, verify = True)
-        if task["status"] not in ["scheduled", "started", "running"]:
+        if task["status"] not in ["scheduled", "queued", "started", "running"]:
             if task["status"] == "finished":
                 return task["status"]
             else:


### PR DESCRIPTION
A queued job is a job that has been scheduled but is waiting for resources to become available. For the purposes of the CLI, this should be treated the same as jobs in a "scheduled" state.