### PR TITLE
Export

### DIFF
--- a/catalyze/commands/backup.py
+++ b/catalyze/commands/backup.py
@@ -76,6 +76,8 @@ def download(service_label, backup_id, filepath):
     service_id = services.get_by_label(session, settings["environmentId"], service_label)
 
     job = jobs.retrieve(session, settings["environmentId"], service_id, backup_id)
+    if job["type"] != "backup" or job["status"] != "finished":
+        output.error("Only 'finished' 'backup' jobs may be downloaded with this command")
 
     output.write("Downloading backup %s" % (backup_id,))
     url = services.get_temporary_url(session, settings["environmentId"], service_id, backup_id)

--- a/catalyze/commands/backup.py
+++ b/catalyze/commands/backup.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 
-import click, json, time
+import click, json, requests
+import tempfile, os, base64, binascii
+
 from catalyze import cli, client, project, output
-from catalyze.helpers import services, jobs, tasks
+from catalyze.helpers import services, jobs, AESCrypto, tasks
 from datetime import datetime
 
 def parse_date(date):
@@ -63,3 +65,31 @@ def restore(service_label, backup_id, skip_poll):
         output.write("Polling until restore is complete.")
         task = tasks.poll_status(session, settings["environmentId"], task_id)
         output.write("\nEnded in status '%s'" % (task["status"],))
+
+@backup.command(short_help = "Download a backup")
+@click.argument("service_label")#, help = "The name of the service.")
+@click.argument("backup_id")
+@click.argument("filepath", type=click.Path(exists=False))
+def download(service_label, backup_id, filepath):
+    settings = project.read_settings()
+    session = client.acquire_session(settings)
+    service_id = services.get_by_label(session, settings["environmentId"], service_label)
+
+    job = jobs.retrieve(session, settings["environmentId"], service_id, backup_id)
+
+    output.write("Downloading backup %s" % (backup_id,))
+    url = services.get_temporary_url(session, settings["environmentId"], service_id, backup_id)
+    r = requests.get(url, stream=True)
+    tmp_filepath = tempfile.mkstemp()
+    with open(tmp_filepath, 'wb+') as f:
+        for chunk in r.iter_content(chunk_size=1024):
+            if chunk:
+                f.write(chunk)
+                f.flush()
+    output.write("Decrypting...")
+    key = binascii.unhexlify(base64.b64decode(job["backup"]["key"]))
+    iv = binascii.unhexlify(base64.b64decode(job["backup"]["iv"]))
+    decryption = AESCrypto.Decryption(tmp_filepath, key, iv)
+    decryption.decrypt(filepath)
+    os.remove(tmp_filepath)
+    output.write("%s downloaded successfully to %s" % (service_label, filepath))

--- a/catalyze/commands/backup.py
+++ b/catalyze/commands/backup.py
@@ -46,8 +46,8 @@ def create(service_label, skip_poll):
     print("Backup started (task ID = %s)" % (task_id,))
     if not skip_poll:
         output.write("Polling until backup finishes.")
-        status = tasks.poll_status(session, settings["environmentId"], task_id)
-        output.write("\nEnded in status '%s'" % (status,))
+        task = tasks.poll_status(session, settings["environmentId"], task_id)
+        output.write("\nEnded in status '%s'" % (task["status"],))
 
 @backup.command(short_help = "Restore from a backup")
 @click.argument("service_label")#, help = "The name of the service.")
@@ -61,5 +61,5 @@ def restore(service_label, backup_id, skip_poll):
     output.write("Restoring (task = %s)" % (task_id,))
     if not skip_poll:
         output.write("Polling until restore is complete.")
-        status = tasks.poll_status(session, settings["environmentId"], task_id)
-        output.write("\nEnded in status '%s'" % (status,))
+        task = tasks.poll_status(session, settings["environmentId"], task_id)
+        output.write("\nEnded in status '%s'" % (task["status"],))

--- a/catalyze/commands/db.py
+++ b/catalyze/commands/db.py
@@ -103,7 +103,7 @@ If there is an unexpected error, please contact Catalyze support (support@cataly
     task = tasks.poll_status(session, settings["environmentId"], task_id)
     output.write("\nEnded in status '%s'" % (task["status"],))
     if task["status"] != "finished":
-        output.write("Export finished with illegal status, aborting.")
+        output.write("Export finished with illegal status \"%s\", aborting." % (task["status"],))
         return
     backup_id = task["id"]
     output.write("Downloading...")

--- a/catalyze/commands/db.py
+++ b/catalyze/commands/db.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 import click
 from catalyze import cli, client, project, output
-from catalyze.helpers import jobs, environments, services, tasks, pods
+from catalyze.helpers import jobs, AESCrypto, environments, services, tasks, pods
 import os, os.path, time, sys
 import requests
 from Crypto import Random
@@ -118,16 +118,7 @@ If there is an unexpected error, please contact Catalyze support (support@cataly
     output.write("Decrypting...")
     key = binascii.unhexlify(base64.b64decode(task["backup"]["key"]))
     iv = binascii.unhexlify(base64.b64decode(task["backup"]["iv"]))
-    with open(tmp_filepath, 'rb') as enc_file:
-        origsize = struct.unpack('<Q', enc_file.read(struct.calcsize('Q')))[0]
-        with open(filepath, 'wb') as plain_file:
-            cipher = AES.new(key, mode=AES.MODE_CBC, IV=iv)
-            chunk_size = 24*1024
-            while True:
-                chunk = enc_file.read(chunk_size)
-                if len(chunk) == 0:
-                    break
-                plain_file.write(cipher.decrypt(chunk))
-            plain_file.truncate(origsize)
+    decryption = AESCrypto.Decryption(tmp_filepath, key, iv)
+    decryption.decrypt(filepath)
     os.remove(tmp_filepath)
     output.write("%s exported successfully to %s" % (database_label, filepath))

--- a/catalyze/helpers/AESCrypto.py
+++ b/catalyze/helpers/AESCrypto.py
@@ -1,0 +1,38 @@
+import base64
+import binascii
+import struct
+
+from Crypto.Cipher import AES
+
+
+class Decryption(object):
+    """
+    Base Decryption class
+    """
+    def __init__(self, filepath, key, iv):
+        self.filepath = filepath
+        self.key = self.decode(key)
+        self.init_vector = self.decode(iv)
+
+    @staticmethod
+    def decode(encoded_text):
+        """
+        Decodes the base64 encoded text.
+        """
+        return binascii.unhexlify(base64.b64decode(encoded_text))
+
+    def decrypt(self, output_filepath):
+        """
+        Decrypt the file and write it to the output filepath.
+        """
+        with open(self.filepath, 'rb') as enc_file:
+            origsize = struct.unpack('<Q', enc_file.read(struct.calcsize('Q')))[0]
+            with open(output_filepath, 'wb') as plain_file:
+                cipher = AES.new(self.key, mode=AES.MODE_CBC, IV=self.init_vector)
+                chunk_size = 24*1024
+                while True:
+                    chunk = enc_file.read(chunk_size)
+                    if len(chunk) == 0:
+                        break
+                    plain_file.write(cipher.decrypt(chunk))
+                plain_file.truncate(origsize)

--- a/catalyze/helpers/services.py
+++ b/catalyze/helpers/services.py
@@ -44,6 +44,10 @@ def restore_backup(session, env_id, svc_id, backup_id):
     }
     return session.post(route, body, verify = True)["taskId"]
 
+def get_temporary_url(session, env_id, svc_id, backup_id):
+    route = "%s/v1/environments/%s/services/%s/backup/%s/url" % (config.paas_host, env_id, svc_id, backup_id)
+    return session.get(route, verify = True)["url"]
+
 def initiate_import(session, env_id, svc_id, file, key, iv, wipe_first, options):
     parameters = {
         "key": key,

--- a/catalyze/helpers/tasks.py
+++ b/catalyze/helpers/tasks.py
@@ -10,7 +10,7 @@ def poll_status(session, env_id, task_id):
         task = session.get(route, verify = True)
         if task["status"] not in ["scheduled", "queued", "started", "running"]:
             if task["status"] == "finished":
-                return task["status"]
+                return task
             else:
                 output.write("")
                 output.error("Error - ended in status '%s'." % (task["status"],))


### PR DESCRIPTION
Ability to export data from a database at the current point in time as well as download data from a previous export.

New commands are:
```
catalyze db export [OPTIONS] DATABASE_LABEL FILEPATH
catalyze backup download [OPTIONS] SERVICE_LABEL BACKUP_ID FILEPATH
```

Example export command:
```
catalyze db export db01 ~/my_download_path.sql
```

Example download command:
```
catalyze backup list db01
# find the ID of the backup you want to download
catalyze backup download db01 dd245781-7951-49c1-8c0d-fc3b4cbd7c22 ~/my_download_path.sql
```